### PR TITLE
Update gexf dead link

### DIFF
--- a/pages/index.hbs
+++ b/pages/index.hbs
@@ -200,7 +200,7 @@ title: getting started
 
     <div class="sixteen columns">
       <div class="textbox">
-        <p>Let's assume we have a graph, exported in <a href="http://gexf.net/format/">GEXF</a> from <a href="http://gephi.org/">Gephi</a>, and we want to display it with sigma. In this tutorial, we will use the graph of character co-occurrences in Victor Hugo’s <a href="http://en.wikipedia.org/wiki/Les_Mis%C3%A9rables"><em>Les Misérables</em></a>, available by default in Gephi.</p>
+        <p>Let's assume we have a graph, exported in <a href="https://gephi.org/gexf/format/">GEXF</a> from <a href="http://gephi.org/">Gephi</a>, and we want to display it with sigma. In this tutorial, we will use the graph of character co-occurrences in Victor Hugo’s <a href="http://en.wikipedia.org/wiki/Les_Mis%C3%A9rables"><em>Les Misérables</em></a>, available by default in Gephi.</p>
         <p>But we also want highlight a node's neighborhood when it is clicked, by drawing every other nodes as grey.</p>
       </div>
     </div>


### PR DESCRIPTION
The link is dead, and http://gexf.net/ now redirects to https://gephi.org/gexf/format/
